### PR TITLE
Fix `escape_int` for bigint type.

### DIFF
--- a/asyncmy/converters.pyx
+++ b/asyncmy/converters.pyx
@@ -45,7 +45,7 @@ cpdef escape_set(set val, str charset, mapping=None):
 cpdef escape_bool(int value, mapping=None):
     return str(int(value))
 
-cpdef escape_int(long value, mapping=None):
+cpdef escape_int(long long value, mapping=None):
     return str(value)
 
 def escape_float(value, mapping=None):


### PR DESCRIPTION
The range of mysql bigint is -9223372036854775808 ~ 9223372036854775807.
but, cpp long int size is -2,147,483,648 to 2,147,483,647.
so, I changed the data type of the escape_int function to long long because an overflow error occurs.