### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ async def run():
         `tinyint`  tinyint
     )"""
         )
+   conn.close()
 
 
 if __name__ == '__main__':
@@ -114,6 +115,7 @@ async def run():
             await cursor.execute("SELECT 1")
             ret = await cursor.fetchone()
             assert ret == (1,)
+    pool.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
added `conn.close()` to the examples

without it the connections seem to stay open on mysql in a Sleep mode untill you land up in `1040, 'Too many connections'` jail