### PR TITLE
Set default _auth_plugin_name for Connection to ""...

### DIFF
--- a/asyncmy/connection.pyx
+++ b/asyncmy/connection.pyx
@@ -297,6 +297,8 @@ class Connection:
         self._reader: Optional[StreamReader] = None
         self._writer: Optional[StreamWriter] = None
 
+        self._auth_plugin_name = ""
+
     def _create_ssl_ctx(self, sslp):
         if isinstance(sslp, ssl.SSLContext):
             return sslp


### PR DESCRIPTION
Set default _auth_plugin_name for Connection to "" in case it doesn't get set later.

Fixes: https://github.com/long2ice/asyncmy/issues/86
