### PR TITLE
build.py: Use setuptools instead of distutils

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-from distutils.command.build_ext import build_ext
+from setuptools.command.build_ext import build_ext
 
 from Cython.Build import cythonize
 


### PR DESCRIPTION
The distutils module is deprecated since Python 3.10.

See also
https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html