### PR TITLE
handle connection close on CancelledError to prevent stale results

### DIFF
--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from asyncmy.connection import Connection
@@ -41,6 +42,7 @@ async def test_cancel_execute(pool, event_loop):
                 await cursor.execute(f"SELECT {index}")
                 ret = await cursor.fetchone()
                 assert ret == (index,)
+
     task = event_loop.create_task(run(1))
     await asyncio.sleep(0)
     task.cancel()

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from asyncmy.connection import Connection
@@ -30,3 +31,19 @@ async def test_acquire(pool):
     await pool.release(conn)
     assert pool.freesize == 1
     assert pool.size == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_execute(pool, event_loop):
+    async def run(index):
+        async with pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(f"SELECT {index}")
+                ret = await cursor.fetchone()
+                assert ret == (index,)
+    task = event_loop.create_task(run(1))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await run(2)


### PR DESCRIPTION
### Description

This PR resolves an issue where canceled queries using connections from a pool leave unintended results that affect subsequent queries. When a query is canceled, the connection is returned to the pool without proper cleanup, causing future queries to receive residual data from the canceled task.

### Solution
- Implemented `_close_on_cancel` to ensure that connections are fully closed and reset when a query is canceled.
- Added a test case to verify that canceled queries do not impact future connections from the pool.

This update ensures clean connection states on cancellation, improving reliability in pooled query operations. This approach is inspired by similar handling in [aiomysql](https://github.com/aio-libs/aiomysql/blob/83aa96e12b1b3f2bd373f60a9c585b6e73f40f52/aiomysql/connection.py#L611)

### Related Issues
- Fixes #100
- Fixes #103
