### PR TITLE
Fix connection closing issue in conncection pool

### DIFF
--- a/asyncmy/connection.pyx
+++ b/asyncmy/connection.pyx
@@ -354,7 +354,7 @@ class Connection:
         return self._last_usage
 
     async def ensure_closed(self):
-        """Close connection without QUIT message."""
+        """Send QUIT message and close connection."""
         if self._connected:
             send_data = i.pack(1) + B.pack(COM_QUIT)
             self._write_bytes(send_data)

--- a/asyncmy/pool.pyx
+++ b/asyncmy/pool.pyx
@@ -95,7 +95,7 @@ class Pool(asyncio.AbstractServer):
 
         while self._free:
             conn = self._free.popleft()
-            conn.close()
+            await conn.ensure_closed()
 
         async with self._cond:
             while self.size > self.freesize:
@@ -133,7 +133,7 @@ class Pool(asyncio.AbstractServer):
 
             elif self._recycle > -1 and self._loop.time() - conn.last_usage > self._recycle:
                 self._free.pop()
-                conn.close()
+                await conn.ensure_closed()
 
             else:
                 self._free.rotate()


### PR DESCRIPTION
Fixes #112 

- Replace `conn.close()` with `conn.ensure_closed()` in `Pool.fill_free_pool()` and `Pool.wait_closed()`.
- Update docstring of `Connection.ensure_closed`
