### PR TITLE
FIX: VALUES syntax deprecation regex

### DIFF
--- a/asyncmy/cursors.pyx
+++ b/asyncmy/cursors.pyx
@@ -11,7 +11,7 @@ from . import errors
 RE_INSERT_VALUES = re.compile(
     r"\s*((?:INSERT|REPLACE)\b.+\bVALUES?\s*)"
     + r"(\(\s*(?:%s|%\(.+\)s)\s*(?:,\s*(?:%s|%\(.+\)s)\s*)*\))"
-    + r"(\s*(?:ON DUPLICATE.*)?);?\s*\Z",
+    + r"(\s*(?:(?:AS|ON DUPLICATE).*)?);?\s*\Z",
     re.IGNORECASE | re.DOTALL,
 )
 logger = logging.getLogger(__package__)


### PR DESCRIPTION
I fixed up the regex for the new format of the insert on duplicate key syntax.  

  https://dev.mysql.com/worklog/task/?id=13325

Fixes https://github.com/long2ice/asyncmy/issues/116 and adds a test on the regex.  We could also mock the execute, call executemany and ensure execute was never called as a way to test the full function.  