### PR TITLE
Added testcase for unsigned bigint

### DIFF
--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -20,3 +20,8 @@ def test_escape_str():
     # so it should accept values that are not strings as well.
     assert escape_str(datetime.date(2023, 6, 2)) == "'2023-06-02'"
     assert escape_str(CustomDate(2023, 6, 2)) == "'2023-06-02'"
+
+
+def test_escape_unsigned_big_int():
+    assert escape_item(2**64-1, "utf-8") == str(2**64-1)
+    assert escape_item(0, "utf-8") == str(0)


### PR DESCRIPTION
Currently passing an int of size 2**64-1 will cause the following exception:
```
OverflowError: Python int too large to convert to C long
```
as mentioned in #35. I added a testcase for this.