### PR TITLE
fix: 'Connection' object has no attribute '_auth_plugin_name'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2
 
+### 0.2.11
+
+- Fix `'Connection' object has no attribute '_auth_plugin_name'` (#86)
+
 ### 0.2.10
 
 - Fix ssl context pass bool.

--- a/asyncmy/connection.pyx
+++ b/asyncmy/connection.pyx
@@ -297,6 +297,8 @@ class Connection:
         self._reader: Optional[StreamReader] = None
         self._writer: Optional[StreamWriter] = None
 
+        self._auth_plugin_name = ""
+
     def _create_ssl_ctx(self, sslp):
         if isinstance(sslp, ssl.SSLContext):
             return sslp


### PR DESCRIPTION
I ran into the same issue.  So creating a PR on top of #87. The authorship of the commit has not been changed.