### PR TITLE
Handle OSError in getpass.getuser()

### DIFF
--- a/asyncmy/connection.pyx
+++ b/asyncmy/connection.pyx
@@ -51,8 +51,10 @@ try:
 
     DEFAULT_USER = getpass.getuser()
     del getpass
-except (ImportError, KeyError):
-    # KeyError occurs when there's no entry in OS database for a current user.
+except (ImportError, KeyError, OSError):
+    # When there's no entry in OS database for a current user:
+    # KeyError is raised in Python 3.12 and below.
+    # OSError is raised in Python 3.13+
     DEFAULT_USER = None
 
 cdef set TEXT_TYPES = {


### PR DESCRIPTION
`getpass.getuser()` now raises `OSError` (in python3.13+). This pr ports the patch from PyMySQL to make asyncmy adapt this change too. Origin:

https://github.com/PyMySQL/PyMySQL/issues/1188
