### PR TITLE
Fix AttributeError on self.ssl in sha256_password auth branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 0.2.12
 
 - Performence improvement， details see [benchmark/README.md](benchmark/README.md).
+- Fix `AttributeError: 'Connection' object has no attribute 'ssl'` in `sha256_password` auth branch. (#147)
 
 ### 0.2.11
 

--- a/asyncmy/connection.pyx
+++ b/asyncmy/connection.pyx
@@ -822,7 +822,7 @@ class Connection:
                 authresp = auth.scramble_caching_sha2(self._password, self.salt)
         elif self._auth_plugin_name == "sha256_password":
             plugin_name = b"sha256_password"
-            if self.ssl and self.server_capabilities & SSL:
+            if self._ssl_context and self.server_capabilities & SSL:
                 authresp = self._password + b"\0"
             elif self._password:
                 authresp = b"\1"  # request public key


### PR DESCRIPTION
## Summary

- Fix missed `self.ssl` → `self._ssl_context` rename in the `sha256_password` authentication branch of `_request_authentication`
- The `sha256_password` authentication branch in `_request_authentication` still referenced the old `self.ssl` instead of `self._ssl_context`, causing `AttributeError` when connecting without SSL
- Update CHANGELOG

## Change

```diff
- if self.ssl and self.server_capabilities & SSL:
+ if self._ssl_context and self.server_capabilities & SSL:
```

## How to Reproduce

1. Connect to a MySQL-compatible database (e.g. Huawei GaussDB) using `sha256_password` auth plugin
2. Without SSL (`ssl=None`)
3. Raises: `AttributeError: 'Connection' object has no attribute 'ssl'`

Fixes #147